### PR TITLE
Add archive fetching utility

### DIFF
--- a/archiver.py
+++ b/archiver.py
@@ -1,0 +1,29 @@
+"""Utilities for retrieving pages from archive.ph."""
+
+from __future__ import annotations
+
+import urllib.parse
+
+import requests
+from bs4 import BeautifulSoup
+
+
+def fetch_archive_html(url: str) -> str:
+    """Return the archived HTML for *url* from archive.ph.
+
+    The function fetches ``http://archive.is/newest/[url]`` using ``requests``
+    and returns the HTML from within ``div#CONTENT`` of the resulting page.
+    ``url`` is URL encoded before it is appended to the archive endpoint.
+    """
+
+    encoded = urllib.parse.quote(url, safe="")
+    archive_url = f"http://archive.is/newest/{encoded}"
+    response = requests.get(archive_url, timeout=10)
+    response.raise_for_status()
+
+    soup = BeautifulSoup(response.text, "html.parser")
+    container = soup.find("div", id="CONTENT")
+    if container is None:
+        raise ValueError("CONTENT not found in archive page")
+
+    return container.decode_contents()

--- a/tests/test_archiver.py
+++ b/tests/test_archiver.py
@@ -1,0 +1,50 @@
+import pytest
+import requests
+
+from archiver import fetch_archive_html
+
+
+class DummyResponse:
+    def __init__(self, text, status_code=200):
+        self.text = text
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"{self.status_code} error")
+
+
+def test_fetch_archive_html_encodes_url(monkeypatch):
+    captured = {}
+
+    def fake_get(url, timeout=10):
+        captured['url'] = url
+        html = '<html><div id="CONTENT"><p>OK</p></div></html>'
+        return DummyResponse(html)
+
+    monkeypatch.setattr(requests, 'get', fake_get)
+
+    result = fetch_archive_html('https://example.com/a b')
+
+    assert result == '<p>OK</p>'
+    assert captured['url'] == 'http://archive.is/newest/https%3A%2F%2Fexample.com%2Fa%20b'
+
+
+def test_fetch_archive_html_raises_for_status(monkeypatch):
+    def fake_get(url, timeout=10):
+        return DummyResponse('boom', status_code=500)
+
+    monkeypatch.setattr(requests, 'get', fake_get)
+
+    with pytest.raises(requests.HTTPError):
+        fetch_archive_html('https://example.com')
+
+
+def test_fetch_archive_html_requires_content(monkeypatch):
+    def fake_get(url, timeout=10):
+        return DummyResponse('<html><body>nope</body></html>')
+
+    monkeypatch.setattr(requests, 'get', fake_get)
+
+    with pytest.raises(ValueError):
+        fetch_archive_html('https://example.com')


### PR DESCRIPTION
## Summary
- implement `fetch_archive_html` to retrieve inner HTML from archive pages
- test archive fetching behaviour including missing content

## Testing
- `PYTHONPATH=. uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6861a740333483268f564a701ff20c7b