### PR TITLE
Add Scraped dataclass for article HTML

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,65 @@
-def main():
-    print("Hello from evening-review!")
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Iterable, List
+
+import requests
+
+from guardian import get_guardian_articles, Article
+from ft import get_ft_articles
+from archiver import fetch_archive_html
+
+
+USER_AGENT = "evening-review/0.1 (+https://example.com/)"
+HEADERS = {"User-Agent": USER_AGENT}
+REQUEST_DELAY = 1.0  # seconds
+
+
+def fetch_html(url: str) -> str:
+    """Fetch ``url`` returning the raw HTML text."""
+    response = requests.get(url, headers=HEADERS, timeout=10)
+    response.raise_for_status()
+    return response.text
+
+
+@dataclass
+class Scraped:
+    """Represents scraped HTML for an article."""
+
+    article: Article
+    html: str
+
+
+def fetch_articles_html(articles: Iterable[Article], use_archive: bool = False) -> List[Scraped]:
+    """Return a list of :class:`Scraped` objects containing article HTML.
+
+    ``articles`` is an iterable of :class:`Article` objects. If ``use_archive`` is
+    ``True`` then the HTML is retrieved via :func:`fetch_archive_html` rather
+    than directly from the site.  The function pauses ``REQUEST_DELAY`` seconds
+    between requests so that we behave politely towards the target servers.
+    """
+
+    result: list[Scraped] = []
+    for article in articles:
+        if use_archive:
+            html = fetch_archive_html(article.url)
+        else:
+            html = fetch_html(article.url)
+        result.append(Scraped(article=article, html=html))
+        time.sleep(REQUEST_DELAY)
+    return result
+
+
+def main() -> None:
+    guardian_articles = get_guardian_articles()
+    ft_articles = get_ft_articles()
+
+    guardian_html = fetch_articles_html(guardian_articles)
+    ft_html = fetch_articles_html(ft_articles, use_archive=True)
+
+    print(f"Fetched {len(guardian_html)} Guardian articles")
+    print(f"Fetched {len(ft_html)} FT articles via archive")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a `Scraped` dataclass
- make `fetch_articles_html` return `List[Scraped]`

## Testing
- `PYTHONPATH=. uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6861a9a766248326a0decc8af133309d