### PR TITLE
Add text extraction method to Scraped

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Where there are paywalled articles we can use archive.ph to grab a copy
 It then bundles these pages up into an epub e-book and sends it to
 my kindle over email.
 
+The HTML scraped from both sites can be converted to plain text using
+the ``Scraped.text()`` method which relies on
+[Trafilatura](https://github.com/adbar/trafilatura).
+
 ## Development
 
 Run `uv sync` to install dependencies

--- a/main.py
+++ b/main.py
@@ -4,6 +4,8 @@ import time
 from dataclasses import dataclass
 from typing import Iterable, List
 
+import trafilatura
+
 import requests
 
 from guardian import get_guardian_articles, Article
@@ -29,6 +31,12 @@ class Scraped:
 
     article: Article
     html: str
+
+    def text(self) -> str:
+        """Return ``self.html`` converted to plain text using Trafilatura."""
+
+        extracted = trafilatura.extract(self.html)
+        return extracted or ""
 
 
 def fetch_articles_html(articles: Iterable[Article], use_archive: bool = False) -> List[Scraped]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.13"
 dependencies = [
     "requests>=2.32.0",
     "beautifulsoup4>=4.13.4",
+    "trafilatura>=2.0.0",
 ]
 
 [dependency-groups]

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -1,0 +1,10 @@
+from guardian import Article
+from main import Scraped
+
+
+def test_scraped_text_simple():
+    html = "<html><body><article><p>First</p><p>Second</p></article></body></html>"
+    scraped = Scraped(article=Article(url="http://example.com", title="T", section="S"), html=html)
+    result = scraped.text()
+    assert "First" in result
+    assert "Second" in result


### PR DESCRIPTION
## Summary
- remove `extractor.py`
- implement `Scraped.text()` using Trafilatura
- update docs to describe using `Scraped.text()`
- adjust tests for the new method

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6861ac4aca2c832690fa39f87b14f898